### PR TITLE
Separate CI/CD Workflows

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,12 +5,9 @@ on:
     workflows: ["Continuous Integration"]
     types:
       - completed
-    branches:
-      - main
 
 jobs:
   deploy-pages:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -38,7 +35,6 @@ jobs:
         uses: actions/deploy-pages@v4
 
   deploy-aws:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     environment:
       name: production
       url: ${{ steps.terraform.outputs.instance_ip }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -7,7 +7,31 @@ on:
       - completed
 
 jobs:
+  validate-deployment:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Download build artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: dist
+          path: ./dist
+
+      - name: Validate artifacts
+        run: |
+          if [ -d "./dist" ]; then
+            echo "✅ Build artifacts are present"
+            ls -la ./dist
+          else
+            echo "❌ Build artifacts are missing"
+            exit 1
+          fi
+
   deploy-pages:
+    needs: validate-deployment
+    if: |
+      github.event.workflow_run.conclusion == 'success' && 
+      github.event.workflow_run.head_branch == 'main'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -35,6 +59,10 @@ jobs:
         uses: actions/deploy-pages@v4
 
   deploy-aws:
+    needs: validate-deployment
+    if: |
+      github.event.workflow_run.conclusion == 'success' && 
+      github.event.workflow_run.head_branch == 'main'
     environment:
       name: production
       url: ${{ steps.terraform.outputs.instance_ip }}
@@ -88,4 +116,4 @@ jobs:
       - name: Deploy with Ansible
         run: |
           cd ansible
-          ansible-playbook -i inventory.yml playbook.yml -e "docker_image=${{ secrets.DOCKER_USERNAME }}/tasklist-react-app:latest"
+          ansible-playbook -i inventory.yml playbook.yml -e "docker_image

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,63 +1,16 @@
-name: CI/CD Pipeline
+name: Continuous Deployment
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+  workflow_run:
+    workflows: ["Continuous Integration"]
+    types:
+      - completed
+    branches:
+      - main
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: "20"
-          cache: "npm"
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Run linter
-        run: npm run lint
-
-      - name: Run tests
-        run: npm test
-
-      - name: Build project
-        run: npm run build
-
-      - name: Upload artifact for GitHub Pages
-        if: github.ref == 'refs/heads/main'
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: ./dist
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to Docker Hub
-        if: github.ref == 'refs/heads/main'
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_TOKEN }}
-
-      - name: Build and push Docker image
-        if: github.ref == 'refs/heads/main'
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          push: true
-          tags: ${{ secrets.DOCKER_USERNAME }}/tasklist-react-app:latest
-
-
   deploy-pages:
-    if: github.ref == 'refs/heads/main'
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -65,8 +18,18 @@ jobs:
       pages: write
       id-token: write
     runs-on: ubuntu-latest
-    needs: build
     steps:
+      - name: Download build artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: dist
+          path: ./dist
+
+      - name: Upload artifact for GitHub Pages
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist
+
       - name: Setup Pages
         uses: actions/configure-pages@v5
 
@@ -75,12 +38,11 @@ jobs:
         uses: actions/deploy-pages@v4
 
   deploy-aws:
-    if: github.ref == 'refs/heads/main'
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     environment:
       name: production
       url: ${{ steps.terraform.outputs.instance_ip }}
     runs-on: ubuntu-latest
-    needs: [build]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    types: [opened, synchronize, reopened]
     branches: [main]
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+    types: [opened, synchronize, reopened]
     branches: [main]
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+name: Continuous Integration
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run linter
+        run: npm run lint
+
+      - name: Run tests
+        run: npm test
+
+      - name: Build project
+        run: npm run build
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: dist
+          path: ./dist
+          retention-days: 1
+
+      - name: Set up Docker Buildx
+        if: github.ref == 'refs/heads/main'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        if: github.ref == 'refs/heads/main'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Build and push Docker image
+        if: github.ref == 'refs/heads/main'
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ secrets.DOCKER_USERNAME }}/tasklist-react-app:latest


### PR DESCRIPTION
This PR splits the CI/CD pipeline into two distinct workflows for better maintainability and clarity.

## Changes
- Created `ci.yml` for build, test, and artifact creation
- Created `cd.yml` for GitHub Pages and AWS deployments
- CD workflow triggers only after successful CI completion
- Added artifact passing between workflows

## Benefits
- Improved readability and maintenance
- Clearer separation of concerns
- Easier debugging of pipeline issues